### PR TITLE
Change Factory from SweetAlert to sweetAlert

### DIFF
--- a/SweetAlert.js
+++ b/SweetAlert.js
@@ -8,7 +8,7 @@
 'use strict';
 
 angular.module('19degrees.ngSweetAlert2', [])
-.factory('SweetAlert', [ '$timeout', '$window', function ( $timeout, $window ) {
+.factory('sweetAlert', [ '$timeout', '$window', function ( $timeout, $window ) {
 
 	var swal = $window.swal;
 	

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
 	"name": "ngSweetAlert2",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"main": "./SweetAlert.js",
 	"authors": [
 		"williamli@19degrees.io"


### PR DESCRIPTION
Change Factory from `SweetAlert` to `sweetAlert`.

PascalCase should be saved for constructors and classes.

Before: `angular.controller(['SweetAlert'], function(SweetAlert) {`
Now: `angular.controller(['sweetAlert'], function(sweetAlert) {`
